### PR TITLE
remove login display for logged in users

### DIFF
--- a/src/app/validation/validation-analyses/validation-analyses.component.html
+++ b/src/app/validation/validation-analyses/validation-analyses.component.html
@@ -187,7 +187,7 @@
         <span [ngClass]="statusClass(submission_status)">{{submission_status}}</span>
       </div>
       <button mat-raised-button color="primary" class="submission_data_button"
-              *ngIf="submission_status !== 'Data is ready'" (click)="onStartSubmissionClick()"
+              *ngIf="submission_status !== 'Data is ready'" (click)="onStartSubmissionClick(private_submission)"
               [disabled]="isSubmissionDisabled(submission_status)">
         Start submission to ENA
       </button>
@@ -209,10 +209,10 @@
   </div>
 
   <div *ngIf="submissionStarted === true" fxLayout="row wrap" fxLayout.lt-md="column" fxLayoutGap="6%">
-    <div  fxFlex="47" [hidden]="disableAuthForm">
+    <div  fxFlex="47" [hidden]="disableAuthForm" *ngIf="!_userService.token">
       <h3 style="margin: 10px 0 20px 0;">Submit data to ENA</h3>
       <form (ngSubmit)="onSubmit()" #enaForm="ngForm">
-        <div class="form-group" *ngIf="!_userService.token">
+        <div class="form-group">
           <label for="aapUsername">Username</label>
           <input class="form-control" id="aapUsername"
                  placeholder="Enter your username" required [(ngModel)]="model.username" name="username"
@@ -227,7 +227,7 @@
           </div>
         </div>
 
-        <div class="form-group" *ngIf="!_userService.token">
+        <div class="form-group">
           <label for="aapPassword">Password</label>
           <input type="password" class="form-control" id="aapPassword" placeholder="Password"
                  required [(ngModel)]="model.password" name="password" #password="ngModel">

--- a/src/app/validation/validation-analyses/validation-analyses.component.ts
+++ b/src/app/validation/validation-analyses/validation-analyses.component.ts
@@ -104,7 +104,6 @@ export class ValidationAnalysesComponent implements OnInit, OnDestroy {
     this.metadata_template_without_examples = analysis_metadata_template_without_examples;
     if (this._userService.token) {
       this.private_submission = true;
-      this.submission_message = 'Choose submission server';
     }
     this.tooltipUpdate = '• This action will update the analysis details with the provided metadata. \n' +
       '• Please ensure that the submitted spreadsheet contains the original alias used during initial submission. \n' +
@@ -447,8 +446,11 @@ export class ValidationAnalysesComponent implements OnInit, OnDestroy {
     return validation_service_url_download + '/submission/download_template/' + this.fileid;
   }
 
-  onStartSubmissionClick() {
+  onStartSubmissionClick(privateSubmission) {
     this.submissionStarted = !this.submissionStarted;
+    if (privateSubmission) {
+      this.onSubmit();
+    }
   }
 
   submissionMessageClass() {

--- a/src/app/validation/validation-experiments/validation-experiments.component.html
+++ b/src/app/validation/validation-experiments/validation-experiments.component.html
@@ -186,7 +186,7 @@
       </div>
       <button  mat-raised-button color="primary" class="submission_data_button"
               *ngIf="submission_status !== 'Data is ready' && submission_status !== 'Failed to convert data'"
-              (click)="onStartSubmissionClick()"
+              (click)="onStartSubmissionClick(private_submission)"
               [disabled]="isSubmissionDisabled(submission_status)">
         Start submission to ENA
       </button>
@@ -208,10 +208,10 @@
   </div>
 
   <div *ngIf="submissionStarted === true" fxLayout="row wrap" fxLayout.lt-md="column" fxLayoutGap="6%">
-    <div fxFlex="47" [hidden]="disableAuthForm">
+    <div fxFlex="47" [hidden]="disableAuthForm" *ngIf="!_userService.token">
       <h3 style="margin: 10px 0 20px 0;">Submit data to ENA</h3>
       <form (ngSubmit)="onSubmit()" #enaForm="ngForm">
-        <div class="form-group" *ngIf="!_userService.token">
+        <div class="form-group">
           <label for="aapUsername">Username</label>
           <input class="form-control" id="aapUsername"
                  placeholder="Enter your username" required [(ngModel)]="model.username" name="username"
@@ -226,7 +226,7 @@
           </div>
         </div>
 
-        <div class="form-group" *ngIf="!_userService.token">
+        <div class="form-group">
           <label for="aapPassword">Password</label>
           <input type="password" class="form-control" id="aapPassword" placeholder="Password"
                  required [(ngModel)]="model.password" name="password" #password="ngModel">

--- a/src/app/validation/validation-experiments/validation-experiments.component.ts
+++ b/src/app/validation/validation-experiments/validation-experiments.component.ts
@@ -105,7 +105,6 @@ export class ValidationExperimentsComponent implements OnInit, OnDestroy {
     this.metadata_template_without_examples = experiment_metadata_template_without_examples;
     if (this._userService.token) {
       this.private_submission = true;
-      this.submission_message = 'Choose submission server';
     }
     this.tooltipUpdate = '• This action will update the experiment details with the provided metadata. \n' +
       '• Please ensure that the submitted spreadsheet contains the original alias used during initial submission. \n' +
@@ -491,8 +490,11 @@ export class ValidationExperimentsComponent implements OnInit, OnDestroy {
     });
   }
 
-  onStartSubmissionClick() {
+  onStartSubmissionClick(privateSubmission) {
     this.submissionStarted = !this.submissionStarted;
+    if (privateSubmission) {
+      this.onSubmit();
+    }
   }
 
   downloadSubmissionResults() {


### PR DESCRIPTION
Remove display of 'login' section for logged-in users. 
Start the submission process as soon as logged-in user clicks on 'Submit to ENA'