### PR TITLE
Fix global search results for timestamped backend indices

### DIFF
--- a/src/app/globalsearch/globalsearch.component.spec.ts
+++ b/src/app/globalsearch/globalsearch.component.spec.ts
@@ -1,22 +1,100 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { of } from 'rxjs';
+
 import { GlobalSearchComponent } from './globalsearch.component';
+import { ApiDataService } from '../services/api-data.service';
 
 describe('GlobalSearchComponent', () => {
   let component: GlobalSearchComponent;
-  let fixture: ComponentFixture<GlobalSearchComponent>;
+  let router: jasmine.SpyObj<Router>;
+  let dataService: jasmine.SpyObj<ApiDataService>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ GlobalSearchComponent ]
-    })
-    .compileComponents();
+  beforeEach(() => {
+    router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    dataService = jasmine.createSpyObj<ApiDataService>('ApiDataService', ['getGSearchData']);
+    const route = { queryParams: of({}) } as unknown as ActivatedRoute;
+    const title = jasmine.createSpyObj<Title>('Title', ['setTitle']);
 
-    fixture = TestBed.createComponent(GlobalSearchComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    // platformId 'server' keeps isBrowser false so ngOnInit does not register window listeners.
+    component = new GlobalSearchComponent(dataService, router, route, title, 'server' as unknown as object);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('normalizeIndexKey', () => {
+    it('strips a timestamped index date prefix', () => {
+      expect(GlobalSearchComponent.normalizeIndexKey('2026_03_26_organism')).toEqual('organism');
+      expect(GlobalSearchComponent.normalizeIndexKey('2026_03_26_specimen')).toEqual('specimen');
+    });
+
+    it('leaves keys without a date prefix unchanged', () => {
+      expect(GlobalSearchComponent.normalizeIndexKey('protocol/samples')).toEqual('protocol/samples');
+      expect(GlobalSearchComponent.normalizeIndexKey('analysis')).toEqual('analysis');
+    });
+  });
+
+  describe('search result keys', () => {
+    it('normalizes timestamped index names returned by the backend', () => {
+      jasmine.clock().install();
+      dataService.getGSearchData.and.returnValue(of({
+        '2026_03_26_organism': { totalHits: 1, searchTerms: [] },
+        '2026_03_26_specimen': { totalHits: 1, searchTerms: [] },
+        'protocol/samples': { totalHits: 1, searchTerms: [] },
+      } as any));
+
+      component.searchText = 'SAMEA9835666';
+      component.onSearch(0);
+      jasmine.clock().tick(1);
+      jasmine.clock().uninstall();
+
+      expect(Object.keys(component.jsonData).sort()).toEqual(['organism', 'protocol/samples', 'specimen']);
+    });
+  });
+
+  describe('navigateToItem', () => {
+    beforeEach(() => {
+      component.searchText = 'SAMEA9835666';
+    });
+
+    it('navigates to the clean entity route with the search term and that entity default sort', () => {
+      component.navigateToItem('organism');
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        ['/organism'],
+        jasmine.objectContaining({
+          queryParams: { searchTerm: 'SAMEA9835666', sortTerm: 'id_number', sortDirection: 'desc' }
+        })
+      );
+    });
+
+    it('does not 404 on a timestamped key — never routes to the raw index name', () => {
+      component.navigateToItem('specimen');
+
+      const route = (router.navigate.calls.mostRecent().args[0] as string[])[0];
+      expect(route).toEqual('/specimen');
+    });
+
+    it('navigates to protocol routes without sort params', () => {
+      component.navigateToItem('protocol/samples');
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        ['/protocol/samples'],
+        jasmine.objectContaining({ queryParams: { searchTerm: 'SAMEA9835666' } })
+      );
+    });
+
+    it('uses an explicit search term when provided', () => {
+      component.navigateToItem('organism', 'PROTO123');
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        ['/organism'],
+        jasmine.objectContaining({
+          queryParams: { searchTerm: 'PROTO123', sortTerm: 'id_number', sortDirection: 'desc' }
+        })
+      );
+    });
   });
 });

--- a/src/app/globalsearch/globalsearch.component.ts
+++ b/src/app/globalsearch/globalsearch.component.ts
@@ -19,6 +19,18 @@ import { HeaderComponent } from '../shared/header/header.component';
     NgPluralCase, KeyValuePipe]
 })
 export class GlobalSearchComponent implements OnInit {
+  // Elasticsearch index names returned by the _gsearch endpoint can be timestamped, e.g. `2026_03_26_organism`.
+  private static readonly INDEX_DATE_PREFIX = /^\d{4}_\d{2}_\d{2}_/;
+  // Default sort applied by each entity list page — mirrored here so global search links land already sorted.
+  private static readonly DEFAULT_SORTS: {[index: string]: [string, string]} = {
+    organism: ['id_number', 'desc'],
+    specimen: ['id_number', 'desc'],
+    dataset: ['accession', 'desc'],
+    file: ['fileName', 'desc'],
+    analysis: ['accession', 'desc'],
+    article: ['pmcId', 'asc'],
+  };
+
   @Input() query: {[index: string]: any} = {};
   searchText = '';
   jsonData: { [key: string]: { totalHits: number, searchTerms: [] } } = {};
@@ -68,7 +80,7 @@ export class GlobalSearchComponent implements OnInit {
         this.showSpinner = true;
         this.dataService.getGSearchData(this.searchText).subscribe(json_data => {
           this.showSpinner = false;
-          this.jsonData = json_data;
+          this.jsonData = this.normalizeResultKeys(json_data);
           this.showResults = true;
         });
       }, time);
@@ -81,6 +93,18 @@ export class GlobalSearchComponent implements OnInit {
       queryParams: { searchText: this.searchText },
       queryParamsHandling: 'merge',
     });
+  }
+
+  static normalizeIndexKey(key: string): string {
+    return key.replace(GlobalSearchComponent.INDEX_DATE_PREFIX, '');
+  }
+
+  private normalizeResultKeys(json_data: { [key: string]: { totalHits: number, searchTerms: [] } }) {
+    const normalized: { [key: string]: { totalHits: number, searchTerms: [] } } = {};
+    for (const [key, value] of Object.entries(json_data)) {
+      normalized[GlobalSearchComponent.normalizeIndexKey(key)] = value;
+    }
+    return normalized;
   }
 
   isJsonDataEmpty(): boolean {
@@ -100,14 +124,18 @@ export class GlobalSearchComponent implements OnInit {
   }
 
   navigateToItem(itemKey: string, searchTerm?: string | null): void {
-    if (itemKey && this.searchText) {
-      void this.router.navigate(
-        [`/${itemKey}`], { relativeTo: this.route, queryParams: { searchTerm: this.searchText }});
+    const term = searchTerm || this.searchText;
+    if (!itemKey || !term) {
+      return;
     }
-    if (itemKey && searchTerm) {
-      void this.router.navigate(
-        [`/${itemKey}`], { relativeTo: this.route, queryParams: { searchTerm: searchTerm }});
+    const route = GlobalSearchComponent.normalizeIndexKey(itemKey);
+    const queryParams: {[index: string]: string} = { searchTerm: term };
+    const sort = GlobalSearchComponent.DEFAULT_SORTS[route];
+    if (sort) {
+      queryParams['sortTerm'] = sort[0];
+      queryParams['sortDirection'] = sort[1];
     }
+    void this.router.navigate([`/${route}`], { relativeTo: this.route, queryParams });
   }
 
 


### PR DESCRIPTION
The _gsearch endpoint returns Elasticsearch index names as result keys, and those names are now timestamped (e.g. 2026_03_26_organism). The frontend used the keys verbatim, so results displayed the raw index name ("1 2026_03_26_organism") and links navigated to /2026_03_26_organism, which 404s since no such route exists.

Strip the YYYY_MM_DD_ index date prefix when results arrive so display, the analysis pluralization check, and routing all use clean entity keys. navigateToItem now routes to the normalized path and appends each entity's default sort (sortTerm/sortDirection), matching the list pages.

Add unit tests covering key normalization and navigation.